### PR TITLE
CI: Disable au4_build_windows.yml action

### DIFF
--- a/.github/workflows/au4_build_windows.yml
+++ b/.github/workflows/au4_build_windows.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   au4_build_windows:
+    if: github.repository == 'audacity/audacity'
     runs-on: windows-2022
     steps:
     - name: Clone repository


### PR DESCRIPTION
Add a condition to the workflow job to run only when the repository is the main audacity/audacity repo. This avoids unnecessary workflow runs on forks, which fail due to missing secrets.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
